### PR TITLE
jobsets: split cardano-wallet bors/pr jobsets into 3 parts

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -173,9 +173,29 @@ let
       modifier.schedulingshares = 10;
     };
 
-    cardano-wallet = {
-      description = "Cardano Wallet Backend";
+    cardano-wallet-linux = {
+      description = "Cardano Wallet Backend - Linux";
       url = "https://github.com/input-output-hk/cardano-wallet.git";
+      input = "cardano-wallet";
+      modifier.inputs.platform = mkStringInput "linux";
+      branch = "master";
+      prs = walletPrsJSON;
+      bors = true;
+    };
+    cardano-wallet-macos = {
+      description = "Cardano Wallet Backend - macOS";
+      url = "https://github.com/input-output-hk/cardano-wallet.git";
+      input = "cardano-wallet";
+      modifier.inputs.platform = mkStringInput "macos";
+      branch = "master";
+      prs = walletPrsJSON;
+      bors = true;
+    };
+    cardano-wallet-windows = {
+      description = "Cardano Wallet Backend - Windows";
+      url = "https://github.com/input-output-hk/cardano-wallet.git";
+      input = "cardano-wallet";
+      modifier.inputs.platform = mkStringInput "windows";
       branch = "master";
       prs = walletPrsJSON;
       bors = true;


### PR DESCRIPTION
This is an attempt to reduce the amount of memory required to evaluate cardano-wallet.

For bors and PR builds, the jobset is split up by target platform. The master branch jobset is built as before.

I have tested this with:

    jq . < $(nix-build --no-out-link jobsets/default.nix)

And compared the new jobset with that of the master branch. The only differences are in the cardano-wallet jobsets.

I also cleaned up up the jobset modifiers code a little bit. All modifiers use the "genericModifier" pattern.

Please monitor hydra carefully after merging this, to check that jobsets are still updated.

Related: #43.