### PR TITLE
hydra-crystal-notify: Include jobset in eval status

### DIFF
--- a/pkgs/hydra-crystal-notify/src/hydra-notify-class.cr
+++ b/pkgs/hydra-crystal-notify/src/hydra-notify-class.cr
@@ -70,7 +70,7 @@ class HydraNotifier
              :evalHistory => false}
 
     id = project = jobset = type = uri = rev = evalId = owner = repo = queryMsg = nil
-    context = "ci/hydra-eval"
+    baseContext = "ci/hydra-eval"
     timeEpochNow = Time.utc.to_unix
     timeRfc2822Now = Time.utc.to_rfc2822
 
@@ -177,6 +177,8 @@ class HydraNotifier
     end
 
     evalSeen = Hash(String, Hash(String, Bool)).new
+
+    context = "#{baseContext}:#{jobSet}"
 
     # Determine relevant API and DB state history
     if !flags[:evalHashed]


### PR DESCRIPTION
I'm going to split the hydra jobset for cardano-wallet, to reduce memory consumption of a single eval (see #26). I will probably also do it for cardano-node.

But I realised that the GitHub CI status from hydra is `ci/hydra-eval`, which would be ambiguous with multiple jobsets.

What would be great is to have the context name sent as `ci/hydra-eval:Project:jobset`.

After this is deployed, any GitHub branch protections or `bors.toml` files which have `ci/hydra-eval` would need to be updated.