### PR TITLE
Prune old Hydra jobsets

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -157,7 +157,7 @@ let
     };
 
     cardano-prelude = {
-      description = "Cardano Byron Proxy";
+      description = "Cardano Prelude";
       url = "https://github.com/input-output-hk/cardano-prelude.git";
       branch = "master";
       prs = cardanoPreludePrsJSON;

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -300,11 +300,13 @@ let
     emailoverride = "";
   };
 
-  # Use to put Bors jobs at the front of the build queue.
+  # Use this modifier to put Bors jobs at the front of the build
+  # queue.
   highPrioJobset = {
     schedulingshares = 420;
   };
 
+  # Modifier to disable keeping of build products for Bors "try" jobs.
   keepNoneJobset = {
     keepnr = 0;
   };
@@ -314,8 +316,11 @@ let
     excludedLabels = import ./pr-excluded-labels.nix;
     justExcluded = filter (label: (elem label.name excludedLabels));
     isEmpty = ls: length ls == 0;
+    notDraft = prInfo: !(prInfo.draft or false);
   in
-    filterAttrs (_: prInfo: isEmpty (justExcluded (prInfo.labels or [])));
+    filterAttrs (_: prInfo:
+      notDraft prInfo &&
+      isEmpty (justExcluded (prInfo.labels or [])));
 
   loadPrsJSON = path: exclusionFilter (builtins.fromJSON (builtins.readFile path));
 

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -24,7 +24,6 @@
 , cardanoAddressesPrsJSON ? ./simple-pr-dummy.json
 , cardanoBasePrsJSON ? ./simple-pr-dummy.json
 , cardanoBenchmarkingPrsJSON ? ./simple-pr-dummy.json
-, cardanoByronProxyPrsJSON ? ./simple-pr-dummy.json
 , cardanoDbSyncPrsJSON ? ./simple-pr-dummy.json
 , cardanoExplorerAppPrsJSON ? ./simple-pr-dummy.json
 , cardanoFaucetPrsJSON ? ./simple-pr-dummy.json
@@ -32,7 +31,6 @@
 , cardanoLedgerSpecsPrsJSON ? ./simple-pr-dummy.json
 , cardanoNodePrsJSON ? ./simple-pr-dummy.json
 , cardanoPreludePrsJSON ? ./simple-pr-dummy.json
-, cardanoPrsJSON ? ./simple-pr-dummy.json
 , cardanoRestPrsJSON ? ./simple-pr-dummy.json
 , cardanoRosettaPrsJSON ? ./simple-pr-dummy.json
 , cardanoRTViewPrsJSON ? ./simple-pr-dummy.json
@@ -43,10 +41,8 @@
 , haskellNixPrsJSON ? ./simple-pr-dummy.json
 , iohkMonitoringPrsJSON ? ./simple-pr-dummy.json
 , iohkNixPrsJSON ? ./simple-pr-dummy.json
-, jormungandrPrsJSON ? ./simple-pr-dummy.json
 , kesPrsJSON ? ./simple-pr-dummy.json
 , ledgerPrsJSON ? ./simple-pr-dummy.json
-, logClassifierPrsJSON ? ./simple-pr-dummy.json
 , nixopsPrsJSON ? ./simple-pr-dummy.json
 , ouroborosNetworkPrsJSON ? ./simple-pr-dummy.json
 , plutusPrsJSON ? ./simple-pr-dummy.json
@@ -54,7 +50,6 @@
 , smashPrsJSON ? ./simple-pr-dummy.json
 , toolsPrsJSON ? ./simple-pr-dummy.json
 , walletPrsJSON ? ./simple-pr-dummy.json
-, rustLibsPrsJSON ? ./simple-pr-dummy.json
 }:
 
 let pkgs = import nixpkgs {}; in
@@ -68,33 +63,6 @@ let
   # These are processed by the mkRepoJobsets function below.
 
   repos = {
-    cardano-sl = {
-      description = "Cardano SL";
-      url = "https://github.com/input-output-hk/cardano-sl.git";
-      input = "cardano";  # corresponds to argument in cardano-sl/release.nix
-      branch = "develop";
-      branches = {
-        master = "master";
-        "1-0" = "release/1.0.x";
-        "1-2" = "release/1.2.0";
-        "1-3" = "release/1.3.1";
-        "2-0" = "release/2.0.0";
-        "3-0-1" = "release/3.0.1";
-      };
-      prs = cardanoPrsJSON;
-      prModifier = fasterBuildJobset;
-      bors = true;
-    };
-
-    jormungandr = {
-      description = "jormungandr";
-      url = "https://github.com/input-output-hk/jormungandr-nix.git";
-      input = "jormungandr";
-      branch = "master";
-      prs = jormungandrPrsJSON;
-      bors = true;
-    };
-
     daedalus = {
       description = "Daedalus Wallet";
       url = "https://github.com/input-output-hk/daedalus.git";
@@ -107,13 +75,6 @@ let
       description = "Plutus Language";
       url = "https://github.com/input-output-hk/plutus.git";
       prs = plutusPrsJSON;
-    };
-
-    log-classifier = {
-      description = "Log Classifier";
-      url = "https://github.com/input-output-hk/log-classifier.git";
-      prs = logClassifierPrsJSON;
-      bors = true;
     };
 
     cardano-addresses = {
@@ -145,14 +106,6 @@ let
       url = "https://github.com/input-output-hk/ouroboros-network.git";
       branch = "master";
       prs = ouroborosNetworkPrsJSON;
-      bors = true;
-    };
-
-    cardano-byron-proxy = {
-      description = "Cardano Byron Proxy";
-      url = "https://github.com/input-output-hk/cardano-byron-proxy.git";
-      branch = "master";
-      prs = cardanoByronProxyPrsJSON;
       bors = true;
     };
 
@@ -226,14 +179,6 @@ let
       branch = "master";
       # TODO: after https://github.com/input-output-hk/cardano-wallet/pull/2301
       # modifier.inputs.platform = mkStringInput "all";
-    };
-
-    rust-libs = {
-      description = "Rust Libs";
-      url = "https://github.com/input-output-hk/rust-libs.nix.git";
-      branch = "master";
-      prs = rustLibsPrsJSON;
-      bors = true;
     };
 
     cardano-shell = {
@@ -353,12 +298,6 @@ let
     };
     enableemail = false;
     emailoverride = "";
-  };
-
-  # Adds an arg which disables optimization for cardano-sl builds
-  withFasterBuild = jobset: recursiveUpdate jobset fasterBuildJobset;
-  fasterBuildJobset = {
-    inputs.fasterBuild = { type = "boolean"; emailresponsible = false; value = "true"; };
   };
 
   # Use to put Bors jobs at the front of the build queue.
@@ -488,9 +427,6 @@ let
   # Jobsets which don't fit into the regular structure
 
   extraJobsets = mapAttrs (name: settings: defaultSettings // settings) ({
-    # Provides cached build projects for PR builds with -O0
-    no-opt-cardano-sl = withFasterBuild mainJobsets.cardano-sl;
-
     # ci-ops (this repo)
     iohk-ops = mkNixops "master" defaultNixpkgsRev;
     iohk-ops-bors-staging = recursiveUpdate (mkNixops "bors-staging" defaultNixpkgsRev) highPrioJobset;

--- a/jobsets/simple-pr-dummy.json
+++ b/jobsets/simple-pr-dummy.json
@@ -14,7 +14,8 @@
         }
       }
     },
-    "title": "Pull request title"
+    "title": "Pull request title",
+    "draft": false
   },
   "30031": {
     "base": {
@@ -41,5 +42,24 @@
       }
     ],
     "title": "Pull request title"
+  },
+  "44": {
+    "base": {
+      "repo": {
+        "clone_url": "https://github.com/user/project.git"
+      }
+    },
+    "head": {
+      "ref": "pr-branch",
+      "repo": {
+        "name": "reponame",
+        "owner": {
+          "login": "githubuser"
+        }
+      }
+    },
+    "title": "Prune old Hydra jobsets",
+    "draft": true,
+    "labels": []
   }
 }

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -16,19 +16,15 @@
          ,"iohkNixPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-nix", "emailresponsible": false }
          ,"ciOpsPrsJSON": { "type": "githubpulls", "value": "input-output-hk ci-ops", "emailresponsible": false }
          ,"haskellNixPrsJSON": { "type": "githubpulls", "value": "input-output-hk haskell.nix", "emailresponsible": false }
-         ,"cardanoPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-sl", "emailresponsible": false }
-         ,"cardanoByronProxyPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-byron-proxy", "emailresponsible": false }
          ,"cardanoPreludePrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-prelude", "emailresponsible": false }
          ,"decentralizedSoftwareUpdatesPrsJSON": { "type": "githubpulls", "value": "input-output-hk decentralized-software-updates", "emailresponsible": false }
          ,"daedalusPrsJSON": { "type": "githubpulls", "value": "input-output-hk daedalus", "emailresponsible": false }
          ,"plutusPrsJSON": { "type": "githubpulls", "value": "input-output-hk plutus", "emailresponsible": false }
-         ,"logClassifierPrsJSON": { "type": "githubpulls", "value": "input-output-hk log-classifier", "emailresponsible": false }
          ,"ouroborosNetworkPrsJSON": { "type": "githubpulls", "value": "input-output-hk ouroboros-network", "emailresponsible": false }
          ,"iohkMonitoringPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-monitoring-framework", "emailresponsible": false }
          ,"ledgerPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ledger", "emailresponsible": false }
          ,"cardanoLedgerSpecsPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ledger-specs", "emailresponsible": false }
          ,"walletPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-wallet", "emailresponsible": false }
-         ,"rustLibsPrsJSON": { "type": "githubpulls", "value": "input-output-hk rust-libs.nix", "emailresponsible": false }
          ,"shellPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-shell", "emailresponsible": false }
          ,"cardanoAddressesPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-addresses", "emailresponsible": false }
          ,"cardanoNodePrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-node", "emailresponsible": false }


### PR DESCRIPTION
1. Cleaned up up the jobset modifiers code a little bit. All modifiers use the "genericModifier" pattern.

2. Remove jobsets for projects which no longer need Hydra builds.
   Unmerged PRs in these will slow down jobset checking of active projects.

3. Don't build PRs with the draft flag set.

4. Add test data for a draft PR.

5. Fix cardano-prelude jobset description.


I have tested this with:

    jq . > pr-44-spec.json < $(nix-build --no-out-link jobsets/default.nix)

And compared the new jobset with that of the master branch. The only differences are in the missing jobsets and updated cardano-prelude description.

Please monitor hydra carefully after merging this, to check that jobsets are still updated.
