### PR TITLE
jobsets: add back cardano-wallet PRs and bors

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -177,8 +177,8 @@ let
       description = "Cardano Wallet Backend";
       url = "https://github.com/input-output-hk/cardano-wallet.git";
       branch = "master";
-      # TODO: after https://github.com/input-output-hk/cardano-wallet/pull/2301
-      # modifier.inputs.platform = mkStringInput "all";
+      prs = walletPrsJSON;
+      bors = true;
     };
 
     cardano-shell = {


### PR DESCRIPTION
I pruned too much in #44.

This puts back cardano-wallet PR and bors jobsets.

Tested with:
```
jq . < $(nix-build --no-out-link jobsets/default.nix) > pr-45-spec.json
```
and diffing that with the same from master branch.
