### PR TITLE
jobsets: disable bors on cardano-addresses and cardano-shell

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -82,7 +82,7 @@ let
       url = "https://github.com/input-output-hk/cardano-addresses.git";
       branch = "master";
       prs = cardanoAddressesPrsJSON;
-      bors = true;
+      bors = false;
     };
 
     cardano-ledger = {
@@ -186,7 +186,7 @@ let
       url = "https://github.com/input-output-hk/cardano-shell.git";
       branch = "master";
       prs = shellPrsJSON;
-      bors = true;
+      bors = false;
     };
 
     cardano-node = {


### PR DESCRIPTION
See also: input-output-hk/cardano-shell#380 and https://github.com/input-output-hk/cardano-addresses

Tested with:
```
jq . < $(nix-build --no-out-link jobsets/default.nix) > pr-47-spec.json
```
