### PR TITLE
jobsets: Remove bors jobsets for cardano-graphql

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -235,7 +235,6 @@ let
       url = "https://github.com/input-output-hk/cardano-graphql.git";
       branch = "master";
       prs = cardanoGraphQLPrsJSON;
-      bors = true;
     };
 
     cardano-faucet = {


### PR DESCRIPTION
This repo does not have a bors.toml or bors branches.

hydra-evaluator is showing errors such as:
```
Dec 14 13:22:09 packet-ipxe-hydra-1 hydra-evaluator[127843]: command `git rev-parse bors/staging' failed with exit status 32768 in /var/lib/hydra/scm/git/5816b6981d0cfda181a7a63df913cf55c78e430df387b17a102fe68219972781 at /nix/store/70gswnhwv6ahrprrbsmi5czm612ixmgy-hydra-0.1.1234.fdd58d/libexec/hydra/lib/Hydra/Helper/Nix.pm line 433.

```