### PR TITLE
jobsets: Enable building draft PRs again

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -317,7 +317,7 @@ let
     notDraft = prInfo: !(prInfo.draft or false);
   in
     filterAttrs (_: prInfo:
-      (notDraft prInfo || hasLabel labels.included prInfo) &&
+      (hasLabel labels.included prInfo) ||
       !(hasLabel labels.excluded prInfo));
 
   loadPrsJSON = path: exclusionFilter (builtins.fromJSON (builtins.readFile path));

--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -38,6 +38,7 @@
 , daedalusPrsJSON ? ./simple-pr-dummy.json
 , decentralizedSoftwareUpdatesPrsJSON ? ./simple-pr-dummy.json
 , explorerPrsJSON ? ./simple-pr-dummy.json
+, haskellNixPrsJSON ? ./simple-pr-dummy.json
 , iohkMonitoringPrsJSON ? ./simple-pr-dummy.json
 , iohkNixPrsJSON ? ./simple-pr-dummy.json
 , kesPrsJSON ? ./simple-pr-dummy.json
@@ -168,6 +169,8 @@ let
       url = "https://github.com/input-output-hk/haskell.nix.git";
       branch = "master";
       bors = true;
+      prs = haskellNixPrsJSON;
+      prFilter = inclusionFilter;
       modifier.schedulingshares = 10;
     };
 
@@ -308,19 +311,17 @@ let
     keepnr = 0;
   };
 
-  # Removes PRs which have any of the labels in ./pr-excluded-labels.nix
-  exclusionFilter = let
-    labels = import ./pr-labels.nix;
-    nonEmpty = ls: length ls != 0;
-    hasLabel = labelList: prInfo:
-      nonEmpty (filter (label: (elem label.name labelList)) (prInfo.labels or []));
-    notDraft = prInfo: !(prInfo.draft or false);
-  in
-    filterAttrs (_: prInfo:
-      (hasLabel labels.included prInfo) ||
-      !(hasLabel labels.excluded prInfo));
+  prHasLabel = labelList: prInfo:
+    length (filter (label: (elem label.name labelList)) (prInfo.labels or [])) != 0;
+  prNotDraft = prInfo: !(prInfo.draft or false);
 
-  loadPrsJSON = path: exclusionFilter (builtins.fromJSON (builtins.readFile path));
+  # Removes PRs which have any of the excluded labels in ./pr-labels.nix
+  exclusionFilter = prInfo: !(prHasLabel (import ./pr-labels.nix).excluded prInfo);
+  # Removes PRs which don't have any of the included labels in ./pr-labels.nix
+  inclusionFilter = prHasLabel (import ./pr-labels.nix).included;
+  
+  loadPrsJSON = prFilter: path: filterAttrs (_: prFilter)
+    (builtins.fromJSON (builtins.readFile path));
 
   # Make jobset for a project default build
   mkJobset = { name, description, url, input, branch, modifier ? {} }: let
@@ -355,10 +356,10 @@ let
   };
 
   # Load the PRs json and make a jobset for each
-  mkJobsetPRs = { name, input, prs, modifier ? {} }:
+  mkJobsetPRs = { name, input, prs, prFilter, modifier ? {} }:
     mapAttrsToList
       (mkJobsetPR { inherit name input modifier; })
-      (loadPrsJSON prs);
+      (loadPrsJSON prFilter prs);
 
   # Add two extra jobsets for the bors staging and trying branches.
   mkJobsetBors = { name, modifier, ... }@args: let
@@ -388,6 +389,7 @@ let
           (mkJobsetPRs {
             inherit name input;
             inherit (info) prs;
+            prFilter = info.prFilter or exclusionFilter;
             modifier = recursiveUpdate modifier (info.prModifier or {});
           }))
         (optionals (info.bors or false)
@@ -423,7 +425,7 @@ let
       };
     };
   };
-  nixopsPrJobsets = listToAttrs (mapAttrsToList makeNixopsPR (loadPrsJSON nixopsPrsJSON));
+  nixopsPrJobsets = listToAttrs (mapAttrsToList makeNixopsPR (loadPrsJSON exclusionFilter nixopsPrsJSON));
 
   ##########################################################################
   # Jobsets which don't fit into the regular structure

--- a/jobsets/pr-excluded-labels.nix
+++ b/jobsets/pr-excluded-labels.nix
@@ -1,1 +1,0 @@
-[ "hydra-dont-build" ]

--- a/jobsets/pr-labels.nix
+++ b/jobsets/pr-labels.nix
@@ -1,0 +1,4 @@
+{
+  excluded = [ "hydra-dont-build" ];
+  included = [ "hydra-do-build" ];
+}

--- a/jobsets/simple-pr-dummy.json
+++ b/jobsets/simple-pr-dummy.json
@@ -58,8 +58,34 @@
         }
       }
     },
-    "title": "Prune old Hydra jobsets",
+    "title": "Example draft PR",
     "draft": true,
     "labels": []
+  },
+  "88": {
+    "base": {
+      "repo": {
+        "clone_url": "https://github.com/user/project.git"
+      }
+    },
+    "head": {
+      "ref": "pr-branch",
+      "repo": {
+        "name": "reponame",
+        "owner": {
+          "login": "githubuser"
+        }
+      }
+    },
+    "labels": [
+      {
+        "color": "00cc00",
+        "default": false,
+        "id": 692360870,
+        "name": "hydra-do-build",
+        "url": "https://api.github.com/repos/input-output-hk/project/labels/hydra-do-build"
+      }
+    ],
+    "title": "Example whitelist PR"
   }
 }


### PR DESCRIPTION
It's a bit unexpected for PRs to not be built. So this puts back Hydra building of draft PRs.

It also re-enables building of Haskell.nix PRs, but only if they are tagged with `hydra-do-build`.

Tested with
```
jq . < $(nix-build --no-out-link jobsets/default.nix) > test.json
```
and comparing the result against master branch.
