### PR TITLE
metadata-server,cardano-metadata-submitter->offchain-metadata-tools

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -29,7 +29,6 @@
 , cardanoFaucetPrsJSON ? ./simple-pr-dummy.json
 , cardanoGraphQLPrsJSON ? ./simple-pr-dummy.json
 , cardanoLedgerSpecsPrsJSON ? ./simple-pr-dummy.json
-, cardanoMetadataSubmitterPrsJSON ? ./simple-pr-dummy.json
 , cardanoNodePrsJSON ? ./simple-pr-dummy.json
 , cardanoOpsPrsJSON ? ./simple-pr-dummy.json
 , cardanoPreludePrsJSON ? ./simple-pr-dummy.json
@@ -45,7 +44,7 @@
 , iohkNixPrsJSON ? ./simple-pr-dummy.json
 , kesPrsJSON ? ./simple-pr-dummy.json
 , ledgerPrsJSON ? ./simple-pr-dummy.json
-, metadataServerPrsJSON ? ./simple-pr-dummy.json
+, offchainMetadataToolsPrsJSON ? ./simple-pr-dummy.json
 , nixopsPrsJSON ? ./simple-pr-dummy.json
 , ouroborosNetworkPrsJSON ? ./simple-pr-dummy.json
 , plutusPrsJSON ? ./simple-pr-dummy.json
@@ -131,14 +130,6 @@ let
       url = "https://github.com/input-output-hk/cardano-ledger.git";
       branch = "master";
       prs = ledgerPrsJSON;
-      bors = true;
-    };
-
-    cardano-metadata-submitter = {
-      description = "A library and CLI for manipulating data for the Metadata Server CIP";
-      url = "https://github.com/input-output-hk/cardano-metadata-submitter.git";
-      branch = "master";
-      prs = cardanoMetadataSubmitterPrsJSON;
       bors = true;
     };
 
@@ -260,11 +251,11 @@ let
       bors = true;
     };
 
-    metadata-server = {
-      description = "Metadata Server";
-      url = "https://github.com/input-output-hk/metadata-server.git";
+    offchain-metadata-tools = {
+      description = "Tools for creating, submitting, and managing off-chain metadata such as multi-asset token metadata";
+      url = "https://github.com/input-output-hk/offchain-metadata-tools.git";
       branch = "master";
-      prs = metadataServerPrsJSON;
+      prs = offchainMetadataToolsPrsJSON;
       bors = true;
     };
 

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -20,7 +20,6 @@
          ,"cardanoFaucetPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-faucet", "emailresponsible": false }
          ,"cardanoGraphQLPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-graphql", "emailresponsible": false }
          ,"cardanoLedgerSpecsPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ledger-specs", "emailresponsible": false }
-         ,"cardanoMetadataSubmitterPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-metadata-submitter", "emailresponsible": false }
          ,"cardanoNodePrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-node", "emailresponsible": false }
          ,"cardanoOpsPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ops", "emailresponsible": false }
          ,"cardanoPreludePrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-prelude", "emailresponsible": false }
@@ -36,7 +35,7 @@
          ,"jormungandrPrsJSON": { "type": "githubpulls", "value": "input-output-hk jormungandr-nix", "emailresponsible": false }
          ,"kesPrsJSON": { "type": "githubpulls", "value": "input-output-hk kes-mmm-sumed25519", "emailresponsible": false }
          ,"ledgerPrsJSON": { "type": "githubpulls", "value": "input-output-hk cardano-ledger", "emailresponsible": false }
-         ,"metadataServerPrsJSON": { "type": "githubpulls", "value": "input-output-hk metadata-server", "emailresponsible": false }
+         ,"offchainMetadataToolsPrsJSON": { "type": "githubpulls", "value": "input-output-hk offchain-metadata-tools", "emailresponsible": false }
          ,"nixopsPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-ops", "emailresponsible": false }
          ,"ouroborosNetworkPrsJSON": { "type": "githubpulls", "value": "input-output-hk ouroboros-network", "emailresponsible": false }
          ,"plutusPrsJSON": { "type": "githubpulls", "value": "input-output-hk plutus", "emailresponsible": false }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -54,7 +54,6 @@ let
       { jobset = "cardano-graphql"; }
       { jobset = "cardano-ledger-specs"; }
       { jobset = "cardano-ledger"; }                    # Below cardano-ledger-specs for regex match
-      { jobset = "cardano-metadata-submitter"; }
       { jobset = "cardano-node"; }
       { jobset = "cardano-ops"; }
       { jobset = "cardano-prelude"; }
@@ -73,7 +72,7 @@ let
       { jobset = "jormungandr"; }
       { jobset = "kes-mmm-sumed25519"; }
       { jobset = "log-classifier"; }
-      { jobset = "metadata-server"; }
+      { jobset = "offchain-metadata-tools"; }
       { jobset = "ouroboros-network"; }
       { jobset = "plutus"; }
       { jobset = "rust-libs"; }


### PR DESCRIPTION
- The metadata-server and cardano-metadata-submitter projects have
  been merged under the new name "offchain-metadata-tools". Update the
  jobset definitions accordingly.