### PR TITLE
Turn off auto updates on Catalina images

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -146,6 +146,7 @@ let
       url = "https://github.com/input-output-hk/cardano-node.git";
       branch = "p2p-master";
       prs = cardanoNodeP2PPrsJSON;
+      prFilter = dontBuildPrsFilter;
       bors = false;
     };
 
@@ -355,6 +356,9 @@ let
   exclusionFilter = prInfo: !(prHasLabel (import ./pr-labels.nix).excluded prInfo);
   # Removes PRs which don't have any of the included labels in ./pr-labels.nix
   inclusionFilter = prHasLabel (import ./pr-labels.nix).included;
+
+  # Build only the repo branch target and not any additional PRs
+  dontBuildPrsFilter = prInfo: false;
 
   loadPrsJSON = prFilter: path: filterAttrs (_: prFilter)
     (builtins.fromJSON (builtins.readFile path));

--- a/modules/macs/guest/apply.sh
+++ b/modules/macs/guest/apply.sh
@@ -43,6 +43,8 @@ launchctl stop com.openssh.sshd
 launchctl unload /System/Library/LaunchDaemons/com.apple.platform.ptmd.plist
 launchctl unload /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
 
+softwareupdate --schedule off
+
 cd /Volumes/CONFIG
 
 cp -rf ./etc/ssh/ssh_host_* /etc/ssh


### PR DESCRIPTION
* Auto updates will trigger a system reboot, which will destroy our secrets, so turn them off on deployment.
* Also adds a fix to hydra cardano-p2p to not double build repo PR commits