### PR TITLE
Add newest Apple root certificate

### DIFF
--- a/modules/macs/guest/apply.sh
+++ b/modules/macs/guest/apply.sh
@@ -157,6 +157,7 @@ EOF
         security import /Volumes/CONFIG/iohk-sign.p12 -P "$SIGNING" -k "ci-signing.keychain" -T /usr/bin/productsign
         security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN" "ci-signing.keychain"
         security import /Volumes/CONFIG/iohk-codesign.cer -k /Library/Keychains/System.keychain
+        security import /Volumes/CONFIG/AppleWWDRCAG3.cer -k /Library/Keychains/System.keychain
         security import /Volumes/CONFIG/iohk-codesign.p12 -P "$CODESIGNING" -k /Library/Keychains/System.keychain -T /usr/bin/codesign
         security import /Volumes/CONFIG/catalyst-ios-dev.p12 -P "$CATALYST" -k /Library/Keychains/System.keychain -T /usr/bin/codesign
         security import /Volumes/CONFIG/catalyst-ios-dist.p12 -P "$CATALYSTDIST" -k /Library/Keychains/System.keychain -T /usr/bin/codesign


### PR DESCRIPTION
The latest Apple root certificate, which expires in 2030, is not installed in the Catalina images by default, but Apple uses this root certificate to sign any newly generated certificates from their web ui.

I recently updated the catalyst-ios-dist.p12 cert after it expired and it will not be trusted without this new root certificate in place. I already have them installed on the builders manually, but this will ensure they are always in place when reprovisioned.