### PR TITLE
Switch marlow-cardano to flakes

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -303,6 +303,7 @@ let
       url = "https://github.com/input-output-hk/marlowe-cardano.git";
       prs = marloweCardanoPrsJSON;
       branch = "main";
+      flake = true;
     };
 
     marlowe-website = {


### PR DESCRIPTION
Switch from legacy release.nix to hydraJobs.

Will make determining evaluation errors easier to detect.