### PR TITLE
Added plutus-flaked jobset

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -369,6 +369,13 @@ let
       prs = plutusPrsJSON;
     };
 
+    plutus-flaked = {
+      description = "Plutus Language (flaked)";
+      url = "github:input-output-hk/plutus";
+      prs = plutusPrsJSON;
+      flake = true;
+    };
+
     plutus-apps = {
       description = "Plutus Application Framework";
       url = "https://github.com/input-output-hk/plutus-apps.git";


### PR DESCRIPTION
I'm migrating the nix code in `plutus` to use [divnix/std](https://github.com/divnix/std) 
I would like to test the new flake-based CI setup.
When I'm sure that my code works, we can remove the current `plutus` jobset and rename the new `plutus-flaked` to `plutus`.

I'm not 100% sure this is going to work though, as this commit introduces a second jobset for the plutus repository (though one is flake based, the other isn't).
Suggestions are welcome