### PR TITLE
Disable bors builds for hydra-poc

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -291,7 +291,7 @@ let
       url = "https://github.com/input-output-hk/hydra-poc.git";
       branch = "master";
       prs = hydraPocPrsJSON;
-      bors = true;
+      bors = false;
     };
 
     iohk-monitoring = {


### PR DESCRIPTION
We are plagued by a negative status check and these are the only jobsets which are having evaluation erros. Also, we don't use bors.