### PR TITLE
Rename hydra-poc -> hydra

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -286,11 +286,11 @@ let
       modifier.schedulingshares = 10;
     };
 
-    hydra-poc = {
+    hydra = {
       description = "Proof of concept for the Hydra Head protocol";
-      url = "https://github.com/input-output-hk/hydra-poc.git";
+      url = "https://github.com/input-output-hk/hydra.git";
       branch = "master";
-      prs = hydraPocPrsJSON;
+      prs = hydraPrsJSON;
       bors = false;
     };
 

--- a/jobsets/spec.json
+++ b/jobsets/spec.json
@@ -34,7 +34,7 @@
          ,"daedalusPrsJSON": { "type": "githubpulls", "value": "input-output-hk daedalus", "emailresponsible": false }
          ,"decentralizedSoftwareUpdatesPrsJSON": { "type": "githubpulls", "value": "input-output-hk decentralized-software-updates", "emailresponsible": false }
          ,"haskellNixPrsJSON": { "type": "githubpulls", "value": "input-output-hk haskell.nix", "emailresponsible": false }
-         ,"hydraPocPrsJSON": { "type": "githubpulls", "value": "input-output-hk hydra-poc", "emailresponsible": false }
+         ,"hydraPrsJSON": { "type": "githubpulls", "value": "input-output-hk hydra", "emailresponsible": false }
          ,"iohkMonitoringPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-monitoring-framework", "emailresponsible": false }
          ,"iohkNixPrsJSON": { "type": "githubpulls", "value": "input-output-hk iohk-nix", "emailresponsible": false }
          ,"jormungandrPrsJSON": { "type": "githubpulls", "value": "input-output-hk jormungandr-nix", "emailresponsible": false }

--- a/modules/hydra-master-main.nix
+++ b/modules/hydra-master-main.nix
@@ -78,7 +78,7 @@ let
       { jobset = "ci-ops"; }
       { jobset = "decentralized-software-updates"; }
       { jobset = "haskell-nix"; }
-      { jobset = "hydra-poc"; }
+      { jobset = "hydra"; }
       { jobset = "iohk-monitoring"; }
       { jobset = "iohk-nix"; }
       { jobset = "iohk-ops"; inputs = "jobsets"; }


### PR DESCRIPTION
The repository name has changed (thanks again @disassembler). For the little time the Hydra CI will be still in use, I think these would be the jobset changes we need.